### PR TITLE
Fixed Friendships Confirmation

### DIFF
--- a/app/helpers/friendship_helper.rb
+++ b/app/helpers/friendship_helper.rb
@@ -1,6 +1,6 @@
 module FriendshipHelper
   def accept_decline(request)
-    render partial: 'accept_decline', locals: { request: request } if request.user.confirm_request?(current_user)
+    render partial: 'accept_decline', locals: { request: request } unless request.user.confirmed_request?(current_user)
   end
 
   def friend_request(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ApplicationRecord
     friendships.find_by(friend_id: friend.id).nil? && friend_request?(friend)
   end
 
-  def confirm_request?(friend)
-    !friendships.find_by(friend_id: friend.id, confirmed: false).nil?
+  def confirmed_request?(friend)
+    friendships.find_by(friend_id: friend.id).confirmed == true
   end
 end

--- a/app/views/friendship/_accept_decline.html.erb
+++ b/app/views/friendship/_accept_decline.html.erb
@@ -1,5 +1,0 @@
-<div>
-<p>Name:<%= request.user.name %></p>
-<%= button_to 'Accept', user_friendship_path(request.user.id, request.id), method: :put, class: 'btn btn-primary' %>
-<%= button_to 'Decline', user_friendship_path(request.user.id, request.id), method: :delete, class: 'btn btn-primary' %>
-</div>

--- a/app/views/friendship/index.html.erb
+++ b/app/views/friendship/index.html.erb
@@ -1,7 +1,0 @@
-<div class="container">
-  <ul>
-  <% @inverted_friendships.reverse_each do |request| %>
-    <%= accept_decline(request)%>
-  <% end %>
-  </ul>
-</div>

--- a/app/views/friendships/_accept_decline.html.erb
+++ b/app/views/friendships/_accept_decline.html.erb
@@ -1,0 +1,5 @@
+<div>
+    <p>Name: <%= request.user.name %></p>
+    <%= button_to 'Accept', user_friendship_path(request.user.id, request.id), method: :put, class: 'btn btn-primary' %>
+    <%= button_to 'Decline', user_friendship_path(request.user.id, request.id), method: :delete, class: 'btn btn-primary' %>
+</div>

--- a/app/views/friendships/index.html.erb
+++ b/app/views/friendships/index.html.erb
@@ -1,0 +1,7 @@
+<div class="container">
+  <ul>
+    <% @inverted_friendships.reverse_each do |request| %>
+      <%= accept_decline(request) %>
+    <% end %>
+  </ul>
+</div>


### PR DESCRIPTION
- Renamed `app/view/friendship` to `app/view/friendships` since the controller is ` friendships`.
- In the `app/helpers/friendship_helper.rb` file, in the `accept_decline` method, the partial only renders when the friend request is confirmed, so I've fixed it to render the partial when friend request is not confirmed.
- In the `User` model, renamed the `confirm_request?` method to `confirmed_request?` also fixed it, because the `find_by(friend_id: friend.id, confirmed: false)` is looking for `confirmed: false` but in the database it's `confirmed: nil`.